### PR TITLE
First Draft of a Data-based  ComponentLink system (with test)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,14 +12,11 @@ find_package(SofaFramework REQUIRED)
 set(HEADER_FILES
         src/NodePhysics/config.h
         src/NodePhysics/initNodePhysics.h
-        src/NodePhysics/MechanicalObject.h        
-        src/NodePhysics/MechanicalObject.inl        
         src/NodePhysics/ObjectLink.h
     )
     
 set(SOURCE_FILES
         src/NodePhysics/initNodePhysics.cpp
-        src/NodePhysics/MechanicalObject.cpp
     )
     
 set(EXTRA_FILES
@@ -43,4 +40,4 @@ sofa_generate_package(
 set (NodePhysics_BUILD_TEST "ON")
 if (NodePhysics_BUILD_TEST)
     add_subdirectory(tests)
-  
+endif (NodePhysics_BUILD_TEST)

--- a/NodePhysicsConfig.cmake.in
+++ b/NodePhysicsConfig.cmake.in
@@ -1,17 +1,17 @@
-# CMake package configuration file for the SofaImplicitField plugin
+# CMake package configuration file for the NodePhysics plugin
 
 @PACKAGE_INIT@
 
 find_package(SofaFramework REQUIRED)
 find_package(SofaPython QUIET)
 
-if(NOT TARGET SofaImplicitField)
-        include("${CMAKE_CURRENT_LIST_DIR}/SofaImplicitFieldTargets.cmake")
+if(NOT TARGET NodePhysics)
+        include("${CMAKE_CURRENT_LIST_DIR}/NodePhysicsTargets.cmake")
 endif()
 
-set(SOFA_HAVE_SOFAIMPLICITFIELD "@SOFA_HAVE_SOFAIMPLICITFIELD@")
+set(SOFA_HAVE_NODEPHYSICS "@SOFA_HAVE_NODEPHYSICS@")
 
-check_required_components(SofaImplicitField)
-set(SofaImplicitField_LIBRARIES SofaImplicitField)
-set(SofaImplicitField_INCLUDE_DIRS @PACKAGE_SOFAIMPLICITFIELD_INCLUDE_DIR@ ${SOFAIMPLICITFIELD_INCLUDE_DIR})
+check_required_components(NodePhysics)
+set(NodePhysics_LIBRARIES NodePhysics)
+set(NodePhysics_INCLUDE_DIRS @PACKAGE_NODEPHYSICS_INCLUDE_DIR@ ${NODEPHYSICS_INCLUDE_DIR})
 

--- a/src/NodePhysics/ObjectLink.h
+++ b/src/NodePhysics/ObjectLink.h
@@ -7,24 +7,23 @@
 
 namespace nodephysics
 {
+using namespace sofa::core::objectmodel;
 
-using sofa::core::objectmodel::Data;
-using sofa::core::objectmodel::BaseData;
 
 template <class T>
-class ObjectLink : public sofa::core::objectmodel::Data<T*>
+class ObjectLink : public Data<T*>
 {
 public:
 
     /** \copydoc BaseData(const BaseData::BaseInitData& init) */
     explicit ObjectLink(const BaseData::BaseInitData& init)
-        : Data<T>(init)
+        : Data<T*>(init)
     {
     }
 
     /** \copydoc Data(const BaseData::BaseInitData&) */
-    explicit ObjectLink(const typename Data<T>::InitData& init)
-        : Data<T>(init)
+    explicit ObjectLink(const typename Data<T*>::InitData& init)
+        : Data<T*>(init)
     {
     }
 
@@ -32,11 +31,11 @@ public:
     //TODO(dmarchal:08/10/2019)Uncomment the deprecated when VS2015 support will be dropped.
     //[[deprecated("Replaced with one with std::string instead of char* version")]]
     ObjectLink( const char* helpMsg=nullptr, bool isDisplayed=true, bool isReadOnly=false)
-        : Data<T>(helpMsg, isDisplayed, isReadOnly) {}
+        : Data<T*>(helpMsg, isDisplayed, isReadOnly) {}
 
     /** \copydoc BaseData(const char*, bool, bool) */
     ObjectLink( const std::string& helpMsg, bool isDisplayed=true, bool isReadOnly=false)
-        : Data<T>(helpMsg, isDisplayed, isReadOnly)
+        : Data<T*>(helpMsg, isDisplayed, isReadOnly)
     {
     }
 
@@ -45,15 +44,20 @@ public:
      *  \param value The default value.
      */
     ObjectLink( const T& value, const char* helpMsg=nullptr, bool isDisplayed=true, bool isReadOnly=false) :
-        Data<T>(value, helpMsg, isDisplayed, isReadOnly)
-    {}
+        Data<T*>(&value, helpMsg, isDisplayed, isReadOnly)
+    {
+        value->d_componentstate.addOutput(this);
+        Data<T*>::setValue(value);
+    }
 
     /** \copydoc BaseData(const char*, bool, bool)
      *  \param value The default value.
      */
     ObjectLink( const T& value, const std::string& helpMsg, bool isDisplayed=true, bool isReadOnly=false)
-        : Data<T>(value, helpMsg, isDisplayed, isReadOnly)
+        : Data<T*>(&value, helpMsg, isDisplayed, isReadOnly)
     {
+        value->d_componentstate.addOutput(this);
+        Data<T*>::setValue(value);
     }
 
     /// Destructor.
@@ -61,60 +65,51 @@ public:
     {}
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-    /// A Link cannot *actually* have a parent, because:
-    /// a data's parent has to be:
-    /// - A Data
-    /// - of the same type
-    ///
-    /// Instead, setParent uses the path to retrieve the linked object, sets its component state as input to the data,
-    /// and stores the parent's reference as this object's value
-    bool setParent(const std::string& path)
+    T* resolvePath(const std::string& path)
     {
-        sofa::simulation::Node* node = static_cast<sofa::simulation::Node*>(this->getOwner()->toBaseNode());
+        if (this->getOwner() == nullptr)
+        {
+            msg_error("ObjectLink") << "Cannot resolve path, as " << this->getName() << " has no owner";
+            return nullptr;
+        }
+        BaseNode* ctx = this->getOwner()->toBaseNode();
+        if (!ctx)
+            ctx = this->getOwner()->toBaseObject()->getContext()->toBaseNode();
+        if (!ctx)
+        {
+            msg_error("ObjectLink") << "Cannot resolve path, as " << this->getOwner()->getName() << " has no context";
+            return nullptr;
+        }
+        BaseData* data;
+        ctx->findDataLinkDest(data, path + ".name", nullptr);
+        return dynamic_cast<T*>(data->getOwner());
+    }
 
-        T* parent = node->getObject(classid(T), path);
-        this->addInput(parent->d_componentstate);
-        this->setValue(parent);
+    virtual bool validParent(BaseData* /*parent*/)
+    {
+        return false;
     }
 
     BaseData* getParent() const { return nullptr; }
 
-    bool setParent(BaseData* /*parent*/, const std::string& /*path*/ = std::string())
+    bool setParent(const std::string& path)
     {
-        return false;
-    }
-
-    bool validParent(BaseData* parentComponentState) override
-    {
-        if (parentComponentState->getName() == "componentState" &&
-                parentComponentState->getOwner() &&
-                dynamic_cast<T*>(parentComponentState->getOwner()))
-            return true;
-        return false;
-    }
-
-    void doSetParent(BaseData* parentComponentState) override
-    {
-        if (validParent(parentComponentState))
+        T* parent = this->resolvePath(path);
+        if (parent)
         {
-            T* parent = dynamic_cast<T*>(parentComponentState->getOwner());
-            this->addInput(parentComponentState);
-            if (parent)
-                this->setValue(parent);
+            setValue(parent);
+            return true;
         }
+        return false;
     }
+
+    void setValue(T* value)
+    {
+        value->d_componentstate.addOutput(this);
+        Data<T*>::setValue(value);
+    }
+
+
 };
 
 }  // namespace sofa::core::objectmodel

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,16 +5,17 @@ find_package(SofaFramework REQUIRED)
 find_package(SofaCommon REQUIRED)
 find_package(SofaTest REQUIRED)
 find_package(SofaGTestMain REQUIRED)
+find_package(SofaSimulation REQUIRED)
+find_package(NodePhysics REQUIRED)
 
 set(SOURCE_FILES
     ObjectLinkTest.cpp
     )
 
-add_executable(${SOURCE_FILES})
+add_executable(NodePhysics_test ${SOURCE_FILES})
 
 target_include_directories(${PROJECT_NAME} PUBLIC "${NodePhysics_INCLUDE_DIRS}")
-
-target_link_libraries(${PROJECT_NAME} SofaTest SofaGTestMain SofaCore NodePhysics)
+target_link_libraries(${PROJECT_NAME} SofaTest SofaGTestMain SofaCore SofaSimulationGraph NodePhysics)
 
 add_test(NAME ${PROJECT_NAME} COMMAND ${PROJECT_NAME})
 

--- a/tests/ObjectLinkTest.cpp
+++ b/tests/ObjectLinkTest.cpp
@@ -5,98 +5,170 @@ using std::string ;
 #include <sofa/core/objectmodel/BaseObject.h>
 using sofa::core::objectmodel::BaseObject ;
 
+#include <sofa/simulation/Simulation.h>
+#include <SofaSimulationGraph/DAGSimulation.h>
+
 #include <NodePhysics/ObjectLink.h>
 
-namespace nodephysics::test
+namespace nodephysics
 {
-  class A : public BaseObject
-  {
-  public:
-    SOFA_CLASS(A, BaseObject)
+class ClassA : public BaseObject
+{
+public:
+    SOFA_CLASS(ClassA, BaseObject);
     
-    A() : Inherit1(),
-	  input(initData(&input, false, "input", "input"))
-	  output(initData(&output, (int)UNDEFINED, "output", "output"))
+    sofa::Data<bool> input;
+    sofa::Data<bool> output;
+    sofa::core::DataTrackerEngine engine;
+
+    ClassA()
+        : Inherit1(),
+          input(initData(&input, false, "input", "input")),
+          output(initData(&output, "output", "output"))
     {
-      addEngineCallback("", {&input}, [](this){
-	  output.setValue(input.getValue());
-	  d_componentstate.setValue(sofa::core::objectmodel::ComponentState::Valid);
-	}, {&output, &d_componentstate})
+        engine.addInput(&input);
+        engine.addOutputs({&d_componentstate, &output});
+        engine.addCallback([=](sofa::core::DataTrackerEngine* e){
+            e->updateAllInputsIfDirty();
+            std::cout << "triggering update callback dependent on input" << std::endl;;
+            output.setValue(input.getValue());
+            d_componentstate.setValue(sofa::core::objectmodel::ComponentState::Valid);
+            e->cleanDirty();
+        });
+        input.setDirtyOutputs();
     }
 
-    ~A() override {}
+    ~ClassA() override {}
 
-    Data<bool> input;
-    Data<bool> output;
-  };
 
-  class B : public BaseObject
-  {
-  public:
-    SOFA_CLASS(B, BaseObject)
-
-    B() : Inherit1(),
-	  inputLink(initData(&inputLink, "inputLink", "inputLink"))
-	  output(initData(&output, (int)UNDEFINED, "output", "output"))
+    inline friend std::istream& operator>>(std::istream& in, ClassA*& /*a*/)
     {
-      addEngineCallback("", {&inputLink}, [](this){
-	  msg_info("triggering update callback dependent on inputLink")
-	  output.setValue(inputLink.getValue()->input.getValue());
-	  d_componentstate.setValue(sofa::core::objectmodel::ComponentState::Valid);
-	}, {&output, &d_componentstate})
+        std::string s;
+        in >> s;
+        //      a.setParent(s);
+        return in;
     }
 
-    ~A() override {}
+    inline friend std::ostream& operator<<(std::ostream& out, const ClassA*& a)
+    {
+        out << "@" << a->getPathName();
+        return out;
+    }
 
-    ObjectLink<A> inputLink;
-    Data<bool> output;
-  };
+};
 
-  
+class ClassB : public BaseObject
+{
+public:
+    SOFA_CLASS(ClassB, BaseObject);
 
+    ClassB()
+        : Inherit1(),
+          inputLink(initData(&inputLink, "inputLink", "inputLink")),
+          output(initData(&output, "output", "output"))
+    {
+        engine.addInput(&inputLink);
+        engine.addOutputs({&d_componentstate, &output});
+        engine.addCallback([=](sofa::core::DataTrackerEngine* e){
+            e->updateAllInputsIfDirty();
+            std::cout << "triggering update callback dependent on inputLink" << std::endl;;
+            output.setValue(inputLink.getValue()->output.getValue());
+            d_componentstate.setValue(sofa::core::objectmodel::ComponentState::Valid);
+            e->cleanDirty();
+        });
+        inputLink.setDirtyOutputs();
+    }
 
-TYPED_TEST(UnilateralPlaneConstraintTest, NormalBehavior) {
-    ASSERT_NO_THROW(this->normalTests()) ;
-}
+    ~ClassB() override {}
 
+    inline friend std::istream& operator>>(std::istream& in, ClassB*& /*a*/)
+    {
+        std::string s;
+        in >> s;
+        //      a.setParent(s);
+        return in;
+    }
 
-  
-}  // nodephysics::test
+    inline friend std::ostream& operator<<(std::ostream& out, const ClassB*& a)
+    {
+        out << "@" << a->getPathName();
+        return out;
+    }
+
+    nodephysics::ObjectLink<ClassA> inputLink;
+    sofa::core::DataTrackerEngine engine;
+    sofa::Data<bool> output;
+};
+
+}  // nodephysics
 
 namespace sofa
 {
 
-  struct ObjectLink_test: public BaseTest
-  {
-    A::SPtr a;
-    B::SPtr b;
+struct ObjectLink_test: public BaseTest
+{
+    nodephysics::ClassA::SPtr a;
+    nodephysics::ClassB::SPtr b;
 
     void SetUp() override
     {
-      a = sofa::core::objectmodel::New<A>();
-      b = sofa::core::objectmodel::New<B>();
-      b.inputLink.setParent(a.getLinkPath());
+        sofa::simulation::Simulation* simu;
+        setSimulation(simu = new sofa::simulation::graph::DAGSimulation());
+
+        Node::SPtr node = simu->createNewGraph("root");
+
+        a = sofa::core::objectmodel::New<nodephysics::ClassA>();
+        a->setName("A");
+        node->addObject(a);
+        sofa::core::objectmodel::BaseObjectDescription bodA("A");
+        bodA.setAttribute("input", "false");
+        a->parse(&bodA);
+
+        b = sofa::core::objectmodel::New<nodephysics::ClassB>();
+        b->setName("B");
+        node->addObject(b);
+        sofa::core::objectmodel::BaseObjectDescription bodB("B");
+        bodB.setAttribute("inputLink", "@/A");
+        bodB.setAttribute("output", "false");
+        b->parse(&bodB);
+
+//        b->inputLink.setValue(a.get());
     }
+
 
     void testObjectLink()
     {
-      ASSERT_TRUE(b.input.getValue()==&a);
+        ASSERT_FALSE(a->input.getValue());
+        ASSERT_FALSE(b->output.getValue());
 
-      // modifying input sets it as dirty
-      a.input.setValue(true);
-      ASSERT_TRUE(b.input.isDirty()==true);
+        a->input.setValue(true); // Changing input value should dirtify all descendency...
 
-      // retrieving B's output triggers the update chain, and stash A's input value into B's output. 
-      b.output.getValue();
-      ASSERT_TRUE(b.output.getValue() == "true");
+        ASSERT_FALSE(a->input.isDirty()); // Value changed, but not dirtified
+
+        ASSERT_TRUE(a->output.isDirty()); // Value dirtified
+        ASSERT_TRUE(a->d_componentstate.isDirty() == true); // Value dirtified
+
+        ASSERT_TRUE(b->inputLink.isDirty()); // Value dirtified
+        ASSERT_TRUE(b->output.isDirty()); // Value dirtified
+        ASSERT_TRUE(b->d_componentstate.isDirty()); // Value dirtified
+
+        b->output.getValue();
+
+        ASSERT_FALSE(b->output.isDirty()); // Value accessed, thus cleaned
+        ASSERT_FALSE(b->inputLink.isDirty()); // Value accessed, thus cleaned
+
+        ASSERT_FALSE(b->d_componentstate.isDirty()); // The component state should be cleaned, as setValue was called in callback!
+
+        ASSERT_FALSE(a->output.isDirty()); // Value accessed, thus cleaned
+        ASSERT_FALSE(a->d_componentstate.isDirty()); // Value accessed, thus cleaned
     }
 
-  };
+};
 
-  // Test
-  TEST_F(ObjectLink_test, testObjectLink )
-  {
+// Test
+TEST_F(ObjectLink_test, testObjectLink )
+{
     this->testObjectLink();
-  }
+}
 
 }  // namespace sofa


### PR DESCRIPTION
This PR proposes a basic first implementation of the Data-based ObjectLinks.

The Data behaves like a normal one, but does not connect, through the parentBaseData, to another datafield of the same template type.
Instead, when calling setParent() while providing a component / Node linkpath, that path is parsed, a connection is made to the connected component's "ComponentState" datafield, and the datafield's value is set to that parsed component.

The behavior is displayed in ObjectLinkTest.cpp, although, there seem to be an (unrelated I think) unexpected behavior with b->d_componentState not getting cleaned in the ClassB callback...